### PR TITLE
Expand Claude Code frontmatter schema to match latest docs

### DIFF
--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -397,22 +397,22 @@ All platform overrides support:
 
 ### Claude Code Overrides
 
-Claude overrides vary by resource type:
+Claude overrides vary by resource type. Field names are HCL attributes; the emitted YAML/JSON key is in parentheses when it differs.
 
 **skill:**
-`argument_hint`, `disable_model_invocation`, `user_invocable`, `allowed_tools`, `model`, `context`, `agent`, `metadata`, `hooks`
+`argument_hint` (`argument-hint`), `arguments`, `when_to_use`, `disable_model_invocation` (`disable-model-invocation`), `user_invocable` (`user-invocable`), `allowed_tools` (`allowed-tools`), `model`, `effort`, `context` (`fork` runs the skill in an isolated subagent), `agent` (subagent type when `context = "fork"`), `paths` (glob patterns for auto-activation), `shell` (`bash` or `powershell`), `metadata`, `hooks`
 
 **command:**
-`argument_hint`, `allowed_tools`, `model`
+Claude Code merged custom commands into the skills system, so commands accept **the same fields as `skill`** above. `CommandClaudeOverride` is a Go type alias for `SkillClaudeOverride` — the two always stay in sync.
 
 **agent:**
-`model`, `color`, `tools`, `hooks`
+`model`, `color`, `tools`, `disallowed_tools` (`disallowedTools`), `permission_mode` (`permissionMode`), `max_turns` (`maxTurns`), `skills` (names of skills to preload), `mcp_servers` (`mcpServers`), `memory` (`user`/`project`/`local`), `background`, `effort`, `isolation` (`worktree` to run in an isolated git worktree), `initial_prompt` (`initialPrompt`), `hooks`
 
 **rule / rules:**
 `paths`
 
 **settings:**
-`allow`, `ask`, `deny`, `env`, `enable_all_project_mcp_servers`, `enabled_mcp_servers`, `disabled_mcp_servers`
+`allow`, `ask`, `deny`, `env`, `enable_all_project_mcp_servers`, `enabled_mcp_servers`, `disabled_mcp_servers`, `respect_gitignore`, `include_co_authored_by`, `model`, `output_style`, `always_thinking_enabled`, `plans_directory`, `additional_directories` (`additionalDirectories` — extra file-access directories), `auto_memory_directory` (`autoMemoryDirectory`), `include_git_instructions` (`includeGitInstructions` — default `true`), `agent` (default subagent for sessions)
 
 ### GitHub Copilot Overrides
 

--- a/internal/adapter/adapter_test.go
+++ b/internal/adapter/adapter_test.go
@@ -122,7 +122,7 @@ func TestClaudeAdapter_PlanCommand(t *testing.T) {
 	expectedContent := `---
 name: deploy
 description: Deploy the application
-argument_hint: [environment]
+argument-hint: [environment]
 model: sonnet
 ---
 Deployment instructions`
@@ -450,8 +450,8 @@ func TestClaudeAdapter_GenerateFrontmatter_Command(t *testing.T) {
 	expected := `---
 name: deploy
 description: Deploy app
-argument_hint: [env]
-allowed_tools:
+argument-hint: [env]
+allowed-tools:
 - Bash
 - Read
 model: opus

--- a/internal/adapter/claude.go
+++ b/internal/adapter/claude.go
@@ -139,7 +139,7 @@ func (a *ClaudeAdapter) GenerateFrontmatter(res resource.Resource, pkg *config.P
 	case *resource.ClaudeSkill:
 		return a.generateSkillFrontmatter(r, pkg)
 	case *resource.ClaudeCommand:
-		return a.generateCommandFrontmatter(r, pkg)
+		return a.generateSkillFrontmatter((*resource.ClaudeSkill)(r), pkg)
 	case *resource.ClaudeSubagent:
 		return a.generateSubagentFrontmatter(r, pkg)
 	case *resource.ClaudeRules:
@@ -223,6 +223,7 @@ func (a *ClaudeAdapter) MergeSettingsConfig(existing map[string]any, settings *r
 	mergeSlice("deny", settings.Deny)
 	mergeSlice("enabledMcpServers", settings.EnabledMCPServers)
 	mergeSlice("disabledMcpServers", settings.DisabledMCPServers)
+	mergeSlice("additionalDirectories", settings.AdditionalDirectories)
 
 	// Merge env map
 	if len(settings.Env) > 0 {
@@ -257,6 +258,15 @@ func (a *ClaudeAdapter) MergeSettingsConfig(existing map[string]any, settings *r
 	}
 	if settings.PlansDirectory != "" {
 		existing["plansDirectory"] = settings.PlansDirectory
+	}
+	if settings.AutoMemoryDirectory != "" {
+		existing["autoMemoryDirectory"] = settings.AutoMemoryDirectory
+	}
+	if settings.IncludeGitInstructions != nil {
+		existing["includeGitInstructions"] = *settings.IncludeGitInstructions
+	}
+	if settings.Agent != "" {
+		existing["agent"] = settings.Agent
 	}
 
 	return existing
@@ -322,7 +332,7 @@ func (a *ClaudeAdapter) planCommand(cmd *resource.ClaudeCommand, pkg *config.Pac
 	if hasFrontmatter(cmd.Content) {
 		content = cmd.Content
 	} else {
-		frontmatter := a.generateCommandFrontmatter(cmd, pkg)
+		frontmatter := a.generateSkillFrontmatter((*resource.ClaudeSkill)(cmd), pkg)
 		content = frontmatter + cmd.Content
 	}
 
@@ -528,8 +538,17 @@ func (a *ClaudeAdapter) generateSkillFrontmatter(skill *resource.ClaudeSkill, pk
 	b.WriteString(fmt.Sprintf("name: %s\n", skill.Name))
 	b.WriteString(fmt.Sprintf("description: %s\n", skill.Description))
 
+	if skill.WhenToUse != "" {
+		b.WriteString(fmt.Sprintf("when_to_use: %s\n", skill.WhenToUse))
+	}
 	if skill.ArgumentHint != "" {
 		b.WriteString(fmt.Sprintf("argument-hint: %s\n", skill.ArgumentHint))
+	}
+	if len(skill.Arguments) > 0 {
+		b.WriteString("arguments:\n")
+		for _, arg := range skill.Arguments {
+			b.WriteString(fmt.Sprintf("- %s\n", arg))
+		}
 	}
 	if skill.DisableModelInvocation {
 		b.WriteString("disable-model-invocation: true\n")
@@ -546,11 +565,23 @@ func (a *ClaudeAdapter) generateSkillFrontmatter(skill *resource.ClaudeSkill, pk
 	if skill.Model != "" {
 		b.WriteString(fmt.Sprintf("model: %s\n", skill.Model))
 	}
+	if skill.Effort != "" {
+		b.WriteString(fmt.Sprintf("effort: %s\n", skill.Effort))
+	}
 	if skill.Context != "" {
 		b.WriteString(fmt.Sprintf("context: %s\n", skill.Context))
 	}
 	if skill.Agent != "" {
 		b.WriteString(fmt.Sprintf("agent: %s\n", skill.Agent))
+	}
+	if len(skill.Paths) > 0 {
+		b.WriteString("paths:\n")
+		for _, p := range skill.Paths {
+			b.WriteString(fmt.Sprintf("- %s\n", p))
+		}
+	}
+	if skill.Shell != "" {
+		b.WriteString(fmt.Sprintf("shell: %s\n", skill.Shell))
 	}
 
 	// Add any additional metadata
@@ -570,32 +601,6 @@ func (a *ClaudeAdapter) generateSkillFrontmatter(skill *resource.ClaudeSkill, pk
 				}
 			}
 		}
-	}
-
-	b.WriteString("---\n")
-	return b.String()
-}
-
-// generateCommandFrontmatter generates YAML frontmatter for a command.
-func (a *ClaudeAdapter) generateCommandFrontmatter(cmd *resource.ClaudeCommand, pkg *config.PackageConfig) string {
-	var b strings.Builder
-	b.WriteString("---\n")
-	b.WriteString(fmt.Sprintf("name: %s\n", cmd.Name))
-	b.WriteString(fmt.Sprintf("description: %s\n", cmd.Description))
-
-	if cmd.ArgumentHint != "" {
-		b.WriteString(fmt.Sprintf("argument_hint: %s\n", cmd.ArgumentHint))
-	}
-
-	if len(cmd.AllowedTools) > 0 {
-		b.WriteString("allowed_tools:\n")
-		for _, tool := range cmd.AllowedTools {
-			b.WriteString(fmt.Sprintf("- %s\n", tool))
-		}
-	}
-
-	if cmd.Model != "" {
-		b.WriteString(fmt.Sprintf("model: %s\n", cmd.Model))
 	}
 
 	b.WriteString("---\n")
@@ -622,6 +627,55 @@ func (a *ClaudeAdapter) generateSubagentFrontmatter(agent *resource.ClaudeSubage
 		for _, tool := range agent.Tools {
 			b.WriteString(fmt.Sprintf("- %s\n", tool))
 		}
+	}
+
+	if len(agent.DisallowedTools) > 0 {
+		b.WriteString("disallowedTools:\n")
+		for _, tool := range agent.DisallowedTools {
+			b.WriteString(fmt.Sprintf("- %s\n", tool))
+		}
+	}
+
+	if agent.PermissionMode != "" {
+		b.WriteString(fmt.Sprintf("permissionMode: %s\n", agent.PermissionMode))
+	}
+
+	if agent.MaxTurns != nil {
+		b.WriteString(fmt.Sprintf("maxTurns: %d\n", *agent.MaxTurns))
+	}
+
+	if len(agent.Skills) > 0 {
+		b.WriteString("skills:\n")
+		for _, s := range agent.Skills {
+			b.WriteString(fmt.Sprintf("- %s\n", s))
+		}
+	}
+
+	if len(agent.MCPServers) > 0 {
+		b.WriteString("mcpServers:\n")
+		for _, s := range agent.MCPServers {
+			b.WriteString(fmt.Sprintf("- %s\n", s))
+		}
+	}
+
+	if agent.Memory != "" {
+		b.WriteString(fmt.Sprintf("memory: %s\n", agent.Memory))
+	}
+
+	if agent.Background {
+		b.WriteString("background: true\n")
+	}
+
+	if agent.Effort != "" {
+		b.WriteString(fmt.Sprintf("effort: %s\n", agent.Effort))
+	}
+
+	if agent.Isolation != "" {
+		b.WriteString(fmt.Sprintf("isolation: %s\n", agent.Isolation))
+	}
+
+	if agent.InitialPrompt != "" {
+		b.WriteString(fmt.Sprintf("initialPrompt: %s\n", agent.InitialPrompt))
 	}
 
 	// Add hooks if present

--- a/internal/resource/agent.go
+++ b/internal/resource/agent.go
@@ -20,12 +20,22 @@ type Agent struct {
 
 // AgentClaudeOverride contains Claude-specific fields for agents (maps to ClaudeSubagent).
 type AgentClaudeOverride struct {
-	Disabled bool                   `hcl:"disabled,optional"`
-	Content  string                 `hcl:"content,optional"`
-	Model    string                 `hcl:"model,optional"`
-	Color    string                 `hcl:"color,optional"`
-	Tools    []string               `hcl:"tools,optional"`
-	Hooks    map[string]interface{} `hcl:"hooks,optional"`
+	Disabled        bool                   `hcl:"disabled,optional"`
+	Content         string                 `hcl:"content,optional"`
+	Model           string                 `hcl:"model,optional"`
+	Color           string                 `hcl:"color,optional"`
+	Tools           []string               `hcl:"tools,optional"`
+	DisallowedTools []string               `hcl:"disallowed_tools,optional"`
+	PermissionMode  string                 `hcl:"permission_mode,optional"`
+	MaxTurns        *int                   `hcl:"max_turns,optional"`
+	Skills          []string               `hcl:"skills,optional"`
+	MCPServers      []string               `hcl:"mcp_servers,optional"`
+	Memory          string                 `hcl:"memory,optional"`
+	Background      bool                   `hcl:"background,optional"`
+	Effort          string                 `hcl:"effort,optional"`
+	Isolation       string                 `hcl:"isolation,optional"`
+	InitialPrompt   string                 `hcl:"initial_prompt,optional"`
+	Hooks           map[string]interface{} `hcl:"hooks,optional"`
 }
 
 // AgentCopilotOverride contains Copilot-specific fields for agents.

--- a/internal/resource/claude.go
+++ b/internal/resource/claude.go
@@ -24,6 +24,12 @@ type ClaudeSkill struct {
 	// ArgumentHint provides a hint shown during autocomplete (e.g., "[filename]")
 	ArgumentHint string
 
+	// Arguments lists named positional arguments for $name substitution in the skill body
+	Arguments []string
+
+	// WhenToUse provides additional context (trigger phrases, example requests) for auto-invocation
+	WhenToUse string
+
 	// DisableModelInvocation prevents Claude from auto-loading this skill; user must invoke manually
 	DisableModelInvocation bool
 
@@ -36,11 +42,20 @@ type ClaudeSkill struct {
 	// Model specifies the model to use when skill is active: "sonnet", "haiku", or "opus"
 	Model string
 
+	// Effort sets the effort level: "low", "medium", "high", "xhigh", or "max"
+	Effort string
+
 	// Context controls execution context; set to "fork" to run in isolated subagent
 	Context string
 
 	// Agent specifies which subagent type to use when Context is "fork" (e.g., "Explore", "Plan")
 	Agent string
+
+	// Paths limits auto-activation to files matching these glob patterns
+	Paths []string
+
+	// Shell selects the shell for embedded commands: "bash" (default) or "powershell"
+	Shell string
 
 	// Metadata contains additional frontmatter fields for the skill
 	Metadata map[string]string
@@ -96,31 +111,12 @@ func (s *ClaudeSkill) Validate() error {
 // ClaudeCommand represents a command for Claude Code.
 // Commands are installed to .claude/commands/{package}-{name}.md
 // and can be invoked by users with /{name} syntax.
-type ClaudeCommand struct {
-	// Name is the block label identifying this command
-	Name string
-
-	// Description explains when and how to use this command
-	Description string
-
-	// Content is the main body/instructions of the command
-	Content string
-
-	// Files lists static files to copy alongside the command
-	Files []FileBlock
-
-	// TemplateFiles lists template files to render and copy
-	TemplateFiles []TemplateFileBlock
-
-	// ArgumentHint provides a hint for command arguments (e.g., "[environment]")
-	ArgumentHint string
-
-	// AllowedTools restricts which tools this command can use
-	AllowedTools []string
-
-	// Model specifies the model to use: "sonnet", "haiku", or "opus"
-	Model string
-}
+//
+// Claude Code merged custom commands into the skills system, so commands and
+// skills share the same frontmatter. This is a named type of ClaudeSkill —
+// distinct for adapter dispatch (different output location) but sharing the
+// full field set and frontmatter emitter.
+type ClaudeCommand ClaudeSkill
 
 // ResourceType returns the HCL block type for Claude commands.
 func (c *ClaudeCommand) ResourceType() string {
@@ -188,11 +184,41 @@ type ClaudeSubagent struct {
 	// Model specifies the model: "inherit", "sonnet", "haiku", or "opus"
 	Model string
 
-	// Color sets the agent's display color: "blue", "green", "yellow", "red", "purple"
+	// Color sets the agent's display color: "blue", "green", "yellow", "red", "purple", "orange", "pink", "cyan"
 	Color string
 
-	// Tools lists the tools this subagent is allowed to use
+	// Tools lists the tools this subagent is allowed to use (inherits all if empty)
 	Tools []string
+
+	// DisallowedTools denies tools (applied before Tools is resolved)
+	DisallowedTools []string
+
+	// PermissionMode controls permission handling: "default", "acceptEdits", "auto", "dontAsk", "bypassPermissions", "plan"
+	PermissionMode string
+
+	// MaxTurns caps the number of agentic turns before stopping
+	MaxTurns *int
+
+	// Skills lists skill names to preload into the subagent's context
+	Skills []string
+
+	// MCPServers lists MCP server names available to this subagent
+	MCPServers []string
+
+	// Memory sets the persistent memory scope: "user", "project", or "local"
+	Memory string
+
+	// Background makes the subagent always run as a background task
+	Background bool
+
+	// Effort sets the effort level: "low", "medium", "high", "xhigh", or "max"
+	Effort string
+
+	// Isolation runs the subagent in an isolated git worktree when set to "worktree"
+	Isolation string
+
+	// InitialPrompt is auto-submitted as the first turn when the subagent runs as main session
+	InitialPrompt string
 
 	// Hooks defines lifecycle hooks scoped to this subagent
 	Hooks map[string]interface{}
@@ -421,6 +447,18 @@ type ClaudeSettings struct {
 
 	// PlansDirectory sets a custom location for plan files
 	PlansDirectory string
+
+	// AdditionalDirectories grants file access beyond the project root
+	AdditionalDirectories []string
+
+	// AutoMemoryDirectory overrides the default auto-memory storage location
+	AutoMemoryDirectory string
+
+	// IncludeGitInstructions controls whether built-in git workflow instructions are included (default: true)
+	IncludeGitInstructions *bool
+
+	// Agent is the name of a custom subagent to run as the default for the session
+	Agent string
 }
 
 // ResourceType returns the HCL block type for Claude settings.

--- a/internal/resource/command.go
+++ b/internal/resource/command.go
@@ -18,13 +18,11 @@ type Command struct {
 }
 
 // CommandClaudeOverride contains Claude-specific fields for commands.
-type CommandClaudeOverride struct {
-	Disabled     bool     `hcl:"disabled,optional"`
-	Content      string   `hcl:"content,optional"`
-	ArgumentHint string   `hcl:"argument_hint,optional"`
-	AllowedTools []string `hcl:"allowed_tools,optional"`
-	Model        string   `hcl:"model,optional"`
-}
+//
+// Claude Code merged custom commands into the skills system, so a command and a
+// skill accept the same frontmatter. This is a type alias — the two names refer
+// to the same Go type so HCL parsing and Go usage stay in lockstep automatically.
+type CommandClaudeOverride = SkillClaudeOverride
 
 // CommandCopilotOverride contains Copilot-specific fields for commands (maps to CopilotPrompt).
 type CommandCopilotOverride struct {

--- a/internal/resource/settings.go
+++ b/internal/resource/settings.go
@@ -29,6 +29,10 @@ type SettingsClaudeOverride struct {
 	OutputStyle                string            `hcl:"output_style,optional"`
 	AlwaysThinkingEnabled      bool              `hcl:"always_thinking_enabled,optional"`
 	PlansDirectory             string            `hcl:"plans_directory,optional"`
+	AdditionalDirectories      []string          `hcl:"additional_directories,optional"`
+	AutoMemoryDirectory        string            `hcl:"auto_memory_directory,optional"`
+	IncludeGitInstructions     *bool             `hcl:"include_git_instructions,optional"`
+	Agent                      string            `hcl:"agent,optional"`
 }
 
 func (s *Settings) ResourceType() string                  { return "settings" }

--- a/internal/resource/skill.go
+++ b/internal/resource/skill.go
@@ -19,16 +19,24 @@ type Skill struct {
 }
 
 // SkillClaudeOverride contains Claude-specific fields for skills.
+// These fields also apply to commands on Claude Code — custom commands were
+// merged into the skills system, so .claude/commands/*.md accepts the same
+// frontmatter as .claude/skills/*/SKILL.md.
 type SkillClaudeOverride struct {
 	Disabled               bool                   `hcl:"disabled,optional"`
 	Content                string                 `hcl:"content,optional"`
 	ArgumentHint           string                 `hcl:"argument_hint,optional"`
+	Arguments              []string               `hcl:"arguments,optional"`
+	WhenToUse              string                 `hcl:"when_to_use,optional"`
 	DisableModelInvocation bool                   `hcl:"disable_model_invocation,optional"`
 	UserInvocable          *bool                  `hcl:"user_invocable,optional"`
 	AllowedTools           []string               `hcl:"allowed_tools,optional"`
 	Model                  string                 `hcl:"model,optional"`
+	Effort                 string                 `hcl:"effort,optional"`
 	Context                string                 `hcl:"context,optional"`
 	Agent                  string                 `hcl:"agent,optional"`
+	Paths                  []string               `hcl:"paths,optional"`
+	Shell                  string                 `hcl:"shell,optional"`
 	Metadata               map[string]string      `hcl:"metadata,optional"`
 	Hooks                  map[string]interface{} `hcl:"hooks,optional"`
 }

--- a/internal/resource/translator.go
+++ b/internal/resource/translator.go
@@ -209,12 +209,17 @@ func TranslateToClaudeSkill(s *Skill) *ClaudeSkill {
 			cs.Content = s.Claude.Content
 		}
 		cs.ArgumentHint = s.Claude.ArgumentHint
+		cs.Arguments = s.Claude.Arguments
+		cs.WhenToUse = s.Claude.WhenToUse
 		cs.DisableModelInvocation = s.Claude.DisableModelInvocation
 		cs.UserInvocable = s.Claude.UserInvocable
 		cs.AllowedTools = s.Claude.AllowedTools
 		cs.Model = s.Claude.Model
+		cs.Effort = s.Claude.Effort
 		cs.Context = s.Claude.Context
 		cs.Agent = s.Claude.Agent
+		cs.Paths = s.Claude.Paths
+		cs.Shell = s.Claude.Shell
 		cs.Metadata = s.Claude.Metadata
 		cs.Hooks = s.Claude.Hooks
 	}
@@ -255,32 +260,24 @@ func TranslateToCopilotSkill(s *Skill) *CopilotSkill {
 
 // TranslateToClaudeCommand converts a universal Command to a Claude-specific command.
 // Returns nil if disabled for Claude.
+//
+// Claude Code merged custom commands into skills, so a Command translates
+// using the same field set as a Skill. We reuse the skill translator and
+// convert to ClaudeCommand (which is a named type of ClaudeSkill).
 func TranslateToClaudeCommand(c *Command) *ClaudeCommand {
-	if !c.IsEnabledForPlatform("claude-code") {
-		return nil
-	}
-
-	cc := &ClaudeCommand{
+	skill := TranslateToClaudeSkill(&Skill{
 		Name:          c.Name,
 		Description:   c.Description,
 		Content:       c.Content,
 		Files:         c.Files,
 		TemplateFiles: c.TemplateFiles,
+		Platforms:     c.Platforms,
+		Claude:        c.Claude, // CommandClaudeOverride is a type alias for SkillClaudeOverride
+	})
+	if skill == nil {
+		return nil
 	}
-
-	if c.Claude != nil {
-		if c.Claude.Disabled {
-			return nil
-		}
-		if c.Claude.Content != "" {
-			cc.Content = c.Claude.Content
-		}
-		cc.ArgumentHint = c.Claude.ArgumentHint
-		cc.AllowedTools = c.Claude.AllowedTools
-		cc.Model = c.Claude.Model
-	}
-
-	return cc
+	return (*ClaudeCommand)(skill)
 }
 
 // TranslateToCopilotPrompt converts a universal Command to a Copilot prompt.
@@ -543,6 +540,16 @@ func TranslateToClaudeSubagent(a *Agent) *ClaudeSubagent {
 		cs.Model = a.Claude.Model
 		cs.Color = a.Claude.Color
 		cs.Tools = a.Claude.Tools
+		cs.DisallowedTools = a.Claude.DisallowedTools
+		cs.PermissionMode = a.Claude.PermissionMode
+		cs.MaxTurns = a.Claude.MaxTurns
+		cs.Skills = a.Claude.Skills
+		cs.MCPServers = a.Claude.MCPServers
+		cs.Memory = a.Claude.Memory
+		cs.Background = a.Claude.Background
+		cs.Effort = a.Claude.Effort
+		cs.Isolation = a.Claude.Isolation
+		cs.InitialPrompt = a.Claude.InitialPrompt
 		cs.Hooks = a.Claude.Hooks
 	}
 
@@ -616,5 +623,9 @@ func TranslateToClaudeSettings(s *Settings) *ClaudeSettings {
 		OutputStyle:                s.Claude.OutputStyle,
 		AlwaysThinkingEnabled:      s.Claude.AlwaysThinkingEnabled,
 		PlansDirectory:             s.Claude.PlansDirectory,
+		AdditionalDirectories:      s.Claude.AdditionalDirectories,
+		AutoMemoryDirectory:        s.Claude.AutoMemoryDirectory,
+		IncludeGitInstructions:     s.Claude.IncludeGitInstructions,
+		Agent:                      s.Claude.Agent,
 	}
 }


### PR DESCRIPTION
Adds missing skill/subagent/settings fields so dex declarations can express the full set of Claude Code frontmatter knobs:

- skill: arguments, when_to_use, effort, paths, shell
- subagent: disallowed_tools, permission_mode, max_turns, skills, mcp_servers, memory, background, effort, isolation, initial_prompt
- settings: additional_directories, auto_memory_directory, include_git_instructions, agent

Unifies command with skill on Claude. Claude Code merged custom commands into the skills system, so CommandClaudeOverride is now a type alias of SkillClaudeOverride and ClaudeCommand is a named type of ClaudeSkill. The skill frontmatter generator emits for both, preventing future drift.

Also corrects command frontmatter key casing (argument-hint, allowed-tools) to match the spec instead of the previous argument_hint/allowed_tools.