### PR TITLE
Bring Cursor support up to date with latest docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Resources are defined once using universal types and automatically translate to 
 
 | Resource Type | Claude Code | GitHub Copilot | Cursor |
 |---------------|:-----------:|:--------------:|:------:|
-| `skill` | Skill | Skill | — |
+| `skill` | Skill | Skill | Skill |
 | `command` | Command | Prompt | Command |
 | `agent` | Subagent | Agent | — |
 | `rule` (merged) | Rule → CLAUDE.md | Instruction → copilot-instructions.md | Rule → AGENTS.md |

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -138,9 +138,9 @@ Skills provide specialized knowledge or capabilities to the AI assistant. Instal
 | `platforms` | list(string) | no | Limit to specific platforms (empty = all) |
 | `claude` | block | no | Claude-specific overrides |
 | `copilot` | block | no | Copilot-specific overrides |
-| `cursor` | block | no | Cursor-specific overrides (disabled = true only) |
+| `cursor` | block | no | Cursor-specific overrides |
 
-**Supported platforms:** Claude Code, GitHub Copilot. Cursor does not support skills (skipped with warning).
+**Supported platforms:** Claude Code, GitHub Copilot, Cursor.
 
 ```hcl
 skill "python-best-practices" {
@@ -150,6 +150,11 @@ skill "python-best-practices" {
   claude {
     allowed_tools = ["Bash", "Read"]
     model         = "sonnet"
+  }
+
+  cursor {
+    license       = "MIT"
+    compatibility = "requires python 3.11"
   }
 }
 ```
@@ -427,8 +432,33 @@ Claude overrides vary by resource type:
 
 ### Cursor Overrides
 
+**skill:**
+`license`, `compatibility`, `disable_model_invocation`, `metadata`
+
+Cursor skills deliberately have a smaller frontmatter than Claude's — no `allowed_tools`, `model`, `argument_hint`, or `context` fields are supported by Cursor.
+
+**command:**
+Cursor commands are plain markdown with no documented frontmatter. Only the generic `disabled` / `content` override fields apply.
+
 **rules:**
-`globs`, `always_apply`
+`globs`, `always_apply` (emitted as `alwaysApply` in the `.mdc` frontmatter)
+
+**mcp_server:**
+`auth` block (for HTTP/SSE servers): `client_id` (required), `client_secret`, `scopes`. Emitted as `CLIENT_ID` / `CLIENT_SECRET` / `scopes` per Cursor's documented casing.
+
+```hcl
+mcp_server "oauth-api" {
+  url = "https://api.example.com/mcp"
+
+  cursor {
+    auth {
+      client_id     = "my-client-id"
+      client_secret = env("CLIENT_SECRET")
+      scopes        = ["read", "write"]
+    }
+  }
+}
+```
 
 ---
 
@@ -436,7 +466,7 @@ Claude overrides vary by resource type:
 
 | Resource Type | Claude Code | GitHub Copilot | Cursor |
 |---------------|:-----------:|:--------------:|:------:|
-| `skill` | Skill | Skill | -- |
+| `skill` | Skill | Skill | Skill |
 | `command` | Command | Prompt | Command |
 | `agent` | Subagent | Agent | -- |
 | `rule` | Rule (CLAUDE.md) | Instruction (copilot-instructions.md) | Rule (AGENTS.md) |

--- a/internal/adapter/adapter_universal_test.go
+++ b/internal/adapter/adapter_universal_test.go
@@ -72,8 +72,7 @@ func emptyPkg() *config.PackageConfig {
 // Cursor Adapter: Unsupported Types Are Logged and Skipped
 // =============================================================================
 
-func TestCursorAdapter_SkillSkippedAndLogged(t *testing.T) {
-	h := withCapturedLogs(t)
+func TestCursorAdapter_SkillProducesPlan(t *testing.T) {
 	adapter, err := Get("cursor")
 	require.NoError(t, err)
 
@@ -85,14 +84,10 @@ func TestCursorAdapter_SkillSkippedAndLogged(t *testing.T) {
 
 	plan, err := adapter.PlanInstallation(skill, emptyPkg(), "/tmp", "/tmp", &InstallContext{})
 	require.NoError(t, err)
-	assert.Empty(t, plan.Files, "skill should produce no files on cursor")
-	assert.Empty(t, plan.MCPEntries, "skill should produce no MCP servers on cursor")
-
-	rec := h.findRecord("resource skipped: not supported by platform")
-	require.NotNil(t, rec, "expected warning log for unsupported skill on cursor")
-	assert.Equal(t, "my-skill", getAttr(rec, "resource"))
-	assert.Equal(t, "skill", getAttr(rec, "type"))
-	assert.Equal(t, "cursor", getAttr(rec, "platform"))
+	require.Len(t, plan.Files, 1)
+	assert.Equal(t, ".cursor/skills/my-skill/SKILL.md", plan.Files[0].Path)
+	expected := "---\nname: my-skill\ndescription: A skill\n---\nSkill content"
+	assert.Equal(t, expected, plan.Files[0].Content)
 }
 
 func TestCursorAdapter_AgentSkippedAndLogged(t *testing.T) {
@@ -213,7 +208,8 @@ func TestCursorAdapter_CommandProducesPlan(t *testing.T) {
 	require.Len(t, plan.Files, 1)
 
 	assert.Equal(t, ".cursor/commands/test-cmd.md", plan.Files[0].Path)
-	assert.Equal(t, "---\ndescription: A command\n---\nCommand content", plan.Files[0].Content)
+	// Cursor commands are plain markdown — no frontmatter is emitted.
+	assert.Equal(t, "Command content", plan.Files[0].Content)
 }
 
 func TestCursorAdapter_RuleProducesPlan(t *testing.T) {

--- a/internal/adapter/cursor.go
+++ b/internal/adapter/cursor.go
@@ -84,8 +84,12 @@ func (a *CursorAdapter) PlanInstallation(res resource.Resource, pkg *config.Pack
 		}
 		return a.planRules(translated, pkg, pkgDir, projectRoot, ctx)
 	case *resource.Skill:
-		slog.Warn("resource skipped: not supported by platform", "resource", r.Name, "type", "skill", "platform", "cursor")
-		return &Plan{}, nil
+		translated := resource.TranslateToCursorSkill(r)
+		if translated == nil {
+			slog.Warn("resource skipped: disabled for platform", "resource", r.Name, "type", "skill", "platform", "cursor")
+			return &Plan{}, nil
+		}
+		return a.planSkill(translated, pkg, pkgDir, projectRoot, ctx)
 	case *resource.Agent:
 		slog.Warn("resource skipped: not supported by platform", "resource", r.Name, "type", "agent", "platform", "cursor")
 		return &Plan{}, nil
@@ -94,6 +98,8 @@ func (a *CursorAdapter) PlanInstallation(res resource.Resource, pkg *config.Pack
 		return &Plan{}, nil
 
 	// Platform-specific types (used internally by translators)
+	case *resource.CursorSkill:
+		return a.planSkill(r, pkg, pkgDir, projectRoot, ctx)
 	case *resource.CursorRule:
 		return a.planRule(r, pkg, pkgDir, projectRoot, ctx)
 	case *resource.CursorMCPServer:
@@ -117,10 +123,10 @@ func (a *CursorAdapter) PlanInstallation(res resource.Resource, pkg *config.Pack
 // GenerateFrontmatter generates YAML frontmatter for a resource.
 func (a *CursorAdapter) GenerateFrontmatter(res resource.Resource, pkg *config.PackageConfig) string {
 	switch r := res.(type) {
+	case *resource.CursorSkill:
+		return a.generateSkillFrontmatter(r, pkg)
 	case *resource.CursorRules:
 		return a.generateRulesFrontmatter(r, pkg)
-	case *resource.CursorCommand:
-		return a.generateCommandFrontmatter(r, pkg)
 	default:
 		return ""
 	}
@@ -153,6 +159,10 @@ func (a *CursorAdapter) MergeCursorMCPConfig(existing map[string]any, pkgName st
 	for _, server := range servers {
 		serverConfig := make(map[string]any)
 
+		if server.Type != "" {
+			serverConfig["type"] = server.Type
+		}
+
 		if server.Type == "stdio" {
 			if server.Command != "" {
 				serverConfig["command"] = server.Command
@@ -171,6 +181,18 @@ func (a *CursorAdapter) MergeCursorMCPConfig(existing map[string]any, pkgName st
 			if len(server.Headers) > 0 {
 				serverConfig["headers"] = server.Headers
 			}
+			if server.Auth != nil {
+				auth := map[string]any{
+					"CLIENT_ID": server.Auth.ClientID,
+				}
+				if server.Auth.ClientSecret != "" {
+					auth["CLIENT_SECRET"] = server.Auth.ClientSecret
+				}
+				if len(server.Auth.Scopes) > 0 {
+					auth["scopes"] = server.Auth.Scopes
+				}
+				serverConfig["auth"] = auth
+			}
 		}
 
 		mcpServers[server.Name] = serverConfig
@@ -184,6 +206,34 @@ func (a *CursorAdapter) MergeCursorMCPConfig(existing map[string]any, pkgName st
 // This method is kept for interface compatibility.
 func (a *CursorAdapter) MergeSettingsConfig(existing map[string]any, settings *resource.ClaudeSettings) map[string]any {
 	return existing
+}
+
+// planSkill creates an installation plan for a Cursor skill.
+// Skills are installed to .cursor/skills/{{pkg}-}{name}/SKILL.md (namespaced or not).
+func (a *CursorAdapter) planSkill(skill *resource.CursorSkill, pkg *config.PackageConfig, pkgDir, root string, ctx *InstallContext) (*Plan, error) {
+	plan := NewPlan(pkg.Meta.Name)
+
+	var skillDirName string
+	if ctx != nil && ctx.Namespace {
+		skillDirName = fmt.Sprintf("%s-%s", pkg.Meta.Name, skill.Name)
+	} else {
+		skillDirName = skill.Name
+	}
+	skillDir := filepath.Join(".cursor", "skills", skillDirName)
+	plan.AddDirectory(skillDir, true)
+
+	var content string
+	if hasFrontmatter(skill.Content) {
+		content = skill.Content
+	} else {
+		frontmatter := a.generateSkillFrontmatter(skill, pkg)
+		content = frontmatter + skill.Content
+	}
+
+	skillFile := filepath.Join(skillDir, "SKILL.md")
+	plan.AddFile(skillFile, content, "")
+
+	return plan, nil
 }
 
 // planRule creates an installation plan for a Cursor rule (singular).
@@ -255,22 +305,14 @@ func (a *CursorAdapter) planRules(rules *resource.CursorRules, pkg *config.Packa
 }
 
 // planCommand creates an installation plan for a Cursor command.
-// Commands are installed to .cursor/commands/{{pkg}-}{name}.md (namespaced or not)
+// Commands are installed to .cursor/commands/{{pkg}-}{name}.md (namespaced or not).
+// Cursor commands have no documented frontmatter — the file is plain markdown.
 func (a *CursorAdapter) planCommand(cmd *resource.CursorCommand, pkg *config.PackageConfig, pkgDir, root string, ctx *InstallContext) (*Plan, error) {
 	plan := NewPlan(pkg.Meta.Name)
 
 	// Create commands directory
 	commandsDir := filepath.Join(".cursor", "commands")
 	plan.AddDirectory(commandsDir, true)
-
-	// Generate frontmatter and content
-	var content string
-	if hasFrontmatter(cmd.Content) {
-		content = cmd.Content
-	} else {
-		frontmatter := a.generateCommandFrontmatter(cmd, pkg)
-		content = frontmatter + cmd.Content
-	}
 
 	// Add command file with optional namespacing
 	var fileName string
@@ -280,7 +322,7 @@ func (a *CursorAdapter) planCommand(cmd *resource.CursorCommand, pkg *config.Pac
 		fileName = fmt.Sprintf("%s.md", cmd.Name)
 	}
 	commandFile := filepath.Join(commandsDir, fileName)
-	plan.AddFile(commandFile, content, "")
+	plan.AddFile(commandFile, cmd.Content, "")
 
 	return plan, nil
 }
@@ -307,12 +349,28 @@ func (a *CursorAdapter) generateRulesFrontmatter(rules *resource.CursorRules, pk
 	return b.String()
 }
 
-// generateCommandFrontmatter generates YAML frontmatter for a command.
-// Commands in Cursor use plain markdown, but we add description in frontmatter.
-func (a *CursorAdapter) generateCommandFrontmatter(cmd *resource.CursorCommand, pkg *config.PackageConfig) string {
+// generateSkillFrontmatter generates YAML frontmatter for a Cursor skill.
+// Per Cursor docs: name/description/license/compatibility/metadata are plain lowercase;
+// disable-model-invocation is kebab-case.
+func (a *CursorAdapter) generateSkillFrontmatter(skill *resource.CursorSkill, pkg *config.PackageConfig) string {
 	var b strings.Builder
 	b.WriteString("---\n")
-	b.WriteString(fmt.Sprintf("description: %s\n", cmd.Description))
+	b.WriteString(fmt.Sprintf("name: %s\n", skill.Name))
+	b.WriteString(fmt.Sprintf("description: %s\n", skill.Description))
+
+	if skill.License != "" {
+		b.WriteString(fmt.Sprintf("license: %s\n", skill.License))
+	}
+	if skill.Compatibility != "" {
+		b.WriteString(fmt.Sprintf("compatibility: %s\n", skill.Compatibility))
+	}
+	if skill.DisableModelInvocation {
+		b.WriteString("disable-model-invocation: true\n")
+	}
+	for k, v := range skill.Metadata {
+		b.WriteString(fmt.Sprintf("%s: %s\n", k, v))
+	}
+
 	b.WriteString("---\n")
 	return b.String()
 }

--- a/internal/adapter/cursor_test.go
+++ b/internal/adapter/cursor_test.go
@@ -65,6 +65,43 @@ func TestCursorAdapter_PlanRule(t *testing.T) {
 	assert.Empty(t, plan.Directories)
 }
 
+func TestCursorAdapter_PlanSkill(t *testing.T) {
+	adapter := &CursorAdapter{}
+
+	skill := &resource.CursorSkill{
+		Name:                   "deploy",
+		Description:            "Deploy the application",
+		Content:                "Deployment instructions",
+		License:                "MIT",
+		Compatibility:          "requires node 20",
+		DisableModelInvocation: true,
+	}
+
+	pkg := &config.PackageConfig{
+		Meta: config.MetaBlock{
+			Name:    "my-plugin",
+			Version: "1.0.0",
+		},
+	}
+
+	plan, err := adapter.PlanInstallation(skill, pkg, "/plugin", "/project", &InstallContext{PackageName: "my-plugin", Namespace: true})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{filepath.Join(".cursor", "skills", "my-plugin-deploy")}, getDirPaths(plan))
+	require.Len(t, plan.Files, 1)
+	assert.Equal(t, filepath.Join(".cursor", "skills", "my-plugin-deploy", "SKILL.md"), plan.Files[0].Path)
+
+	expectedContent := `---
+name: deploy
+description: Deploy the application
+license: MIT
+compatibility: requires node 20
+disable-model-invocation: true
+---
+Deployment instructions`
+	assert.Equal(t, expectedContent, plan.Files[0].Content)
+}
+
 func TestCursorAdapter_PlanMCPServer_Stdio(t *testing.T) {
 	adapter := &CursorAdapter{}
 
@@ -93,6 +130,7 @@ func TestCursorAdapter_PlanMCPServer_Stdio(t *testing.T) {
 	expectedMCPEntries := map[string]any{
 		"mcpServers": map[string]any{
 			"filesystem": map[string]any{
+				"type":    "stdio",
 				"command": "npx",
 				"args":    []string{"-y", "@anthropic/mcp-filesystem"},
 				"env":     map[string]string{"HOME": "/home/user"},
@@ -125,6 +163,7 @@ func TestCursorAdapter_PlanMCPServer_HTTP(t *testing.T) {
 	expectedMCPEntries := map[string]any{
 		"mcpServers": map[string]any{
 			"context7": map[string]any{
+				"type":    "http",
 				"url":     "https://mcp.context7.com/mcp",
 				"headers": map[string]string{"Authorization": "Bearer token"},
 			},
@@ -156,8 +195,49 @@ func TestCursorAdapter_PlanMCPServer_SSE(t *testing.T) {
 	expectedMCPEntries := map[string]any{
 		"mcpServers": map[string]any{
 			"sse-server": map[string]any{
+				"type":    "sse",
 				"url":     "https://api.example.com/sse",
 				"headers": map[string]string{"X-API-Key": "secret"},
+			},
+		},
+	}
+	assert.Equal(t, expectedMCPEntries, plan.MCPEntries)
+}
+
+func TestCursorAdapter_PlanMCPServer_HTTPWithAuth(t *testing.T) {
+	adapter := &CursorAdapter{}
+
+	server := &resource.CursorMCPServer{
+		Name: "oauth-server",
+		Type: "http",
+		URL:  "https://api.example.com/mcp",
+		Auth: &resource.MCPAuth{
+			ClientID:     "my-client-id",
+			ClientSecret: "my-client-secret",
+			Scopes:       []string{"read", "write"},
+		},
+	}
+
+	pkg := &config.PackageConfig{
+		Meta: config.MetaBlock{
+			Name:    "my-plugin",
+			Version: "1.0.0",
+		},
+	}
+
+	plan, err := adapter.PlanInstallation(server, pkg, "/plugin", "/project", &InstallContext{PackageName: "my-plugin", Namespace: false})
+	require.NoError(t, err)
+
+	expectedMCPEntries := map[string]any{
+		"mcpServers": map[string]any{
+			"oauth-server": map[string]any{
+				"type": "http",
+				"url":  "https://api.example.com/mcp",
+				"auth": map[string]any{
+					"CLIENT_ID":     "my-client-id",
+					"CLIENT_SECRET": "my-client-secret",
+					"scopes":        []string{"read", "write"},
+				},
 			},
 		},
 	}
@@ -188,6 +268,7 @@ func TestCursorAdapter_PlanMCPServer_EnvFile(t *testing.T) {
 	expectedMCPEntries := map[string]any{
 		"mcpServers": map[string]any{
 			"env-server": map[string]any{
+				"type":    "stdio",
 				"command": "node",
 				"args":    []string{"server.js"},
 				"envFile": ".env.local",
@@ -316,11 +397,8 @@ func TestCursorAdapter_PlanCommand(t *testing.T) {
 	require.Len(t, plan.Files, 1)
 	assert.Equal(t, filepath.Join(".cursor", "commands", "my-plugin-deploy.md"), plan.Files[0].Path)
 
-	expectedContent := `---
-description: Deploy the application
----
-Deploy this app to production.`
-	assert.Equal(t, expectedContent, plan.Files[0].Content)
+	// Cursor commands are plain markdown — no frontmatter.
+	assert.Equal(t, "Deploy this app to production.", plan.Files[0].Content)
 }
 
 func TestCursorAdapter_PlanInstallation_UnsupportedType(t *testing.T) {
@@ -387,19 +465,45 @@ description: Simple rules
 	assert.Equal(t, expected, frontmatter)
 }
 
-func TestCursorAdapter_GenerateFrontmatter_Command(t *testing.T) {
+func TestCursorAdapter_GenerateFrontmatter_Skill_Minimal(t *testing.T) {
 	adapter := &CursorAdapter{}
 
-	cmd := &resource.CursorCommand{
+	skill := &resource.CursorSkill{
 		Name:        "deploy",
 		Description: "Deploy the app",
 	}
 
 	pkg := &config.PackageConfig{}
 
-	frontmatter := adapter.GenerateFrontmatter(cmd, pkg)
+	frontmatter := adapter.GenerateFrontmatter(skill, pkg)
 	expected := `---
+name: deploy
 description: Deploy the app
+---
+`
+	assert.Equal(t, expected, frontmatter)
+}
+
+func TestCursorAdapter_GenerateFrontmatter_Skill_Full(t *testing.T) {
+	adapter := &CursorAdapter{}
+
+	skill := &resource.CursorSkill{
+		Name:                   "deploy",
+		Description:            "Deploy the app",
+		License:                "MIT",
+		Compatibility:          "requires node 20",
+		DisableModelInvocation: true,
+	}
+
+	pkg := &config.PackageConfig{}
+
+	frontmatter := adapter.GenerateFrontmatter(skill, pkg)
+	expected := `---
+name: deploy
+description: Deploy the app
+license: MIT
+compatibility: requires node 20
+disable-model-invocation: true
 ---
 `
 	assert.Equal(t, expected, frontmatter)
@@ -408,11 +512,15 @@ description: Deploy the app
 func TestCursorAdapter_GenerateFrontmatter_UnknownType(t *testing.T) {
 	adapter := &CursorAdapter{}
 
+	// CursorCommand returns "" — Cursor commands are plain markdown.
+	cmd := &resource.CursorCommand{Name: "test", Description: "test", Content: "content"}
+	pkg := &config.PackageConfig{}
+	frontmatter := adapter.GenerateFrontmatter(cmd, pkg)
+	assert.Equal(t, "", frontmatter)
+
 	// CursorRule doesn't generate frontmatter (it's merged content)
 	rule := &resource.CursorRule{Name: "test", Description: "test", Content: "content"}
-	pkg := &config.PackageConfig{}
-
-	frontmatter := adapter.GenerateFrontmatter(rule, pkg)
+	frontmatter = adapter.GenerateFrontmatter(rule, pkg)
 	assert.Equal(t, "", frontmatter)
 
 	// CursorMCPServer doesn't generate frontmatter
@@ -442,6 +550,7 @@ func TestCursorAdapter_MergeCursorMCPConfig_NewConfig(t *testing.T) {
 	expected := map[string]any{
 		"mcpServers": map[string]any{
 			"server1": map[string]any{
+				"type":    "stdio",
 				"command": "npx",
 				"args":    []string{"-y", "@mcp/server"},
 			},
@@ -481,6 +590,7 @@ func TestCursorAdapter_MergeCursorMCPConfig_MergeExisting(t *testing.T) {
 				"args":    []string{"server.js"},
 			},
 			"new-server": map[string]any{
+				"type":    "stdio",
 				"command": "npx",
 				"args":    []string{"-y", "@mcp/new"},
 				"env":     map[string]string{"KEY": "value"},
@@ -516,6 +626,7 @@ func TestCursorAdapter_MergeCursorMCPConfig_OverwriteExisting(t *testing.T) {
 	expected := map[string]any{
 		"mcpServers": map[string]any{
 			"server": map[string]any{
+				"type":    "stdio",
 				"command": "new-command",
 				"args":    []string{"new-arg"},
 			},
@@ -552,13 +663,16 @@ func TestCursorAdapter_MergeCursorMCPConfig_MultipleServers(t *testing.T) {
 	expected := map[string]any{
 		"mcpServers": map[string]any{
 			"stdio-server": map[string]any{
+				"type":    "stdio",
 				"command": "npx",
 				"args":    []string{"-y", "@mcp/stdio"},
 			},
 			"http-server": map[string]any{
-				"url": "https://api.example.com/mcp",
+				"type": "http",
+				"url":  "https://api.example.com/mcp",
 			},
 			"sse-server": map[string]any{
+				"type":    "sse",
 				"url":     "https://api.example.com/sse",
 				"headers": map[string]string{"Auth": "token"},
 			},
@@ -588,6 +702,7 @@ func TestCursorAdapter_MergeCursorMCPConfig_EmptyExistingNoServers(t *testing.T)
 		"otherKey": "otherValue",
 		"mcpServers": map[string]any{
 			"server": map[string]any{
+				"type":    "stdio",
 				"command": "cmd",
 			},
 		},

--- a/internal/installer/installer_mcp_test.go
+++ b/internal/installer/installer_mcp_test.go
@@ -199,10 +199,11 @@ package "mcp-test" {
 	err = json.Unmarshal(mcpData, &mcpConfig)
 	require.NoError(t, err)
 
-	// Verify full MCP config for Cursor
+	// Verify full MCP config for Cursor — `type` is emitted per modern Cursor schema.
 	assert.Equal(t, map[string]any{
 		"mcpServers": map[string]any{
 			"context7": map[string]any{
+				"type":    "http",
 				"url":     "https://mcp.context7.com/mcp",
 				"headers": map[string]any{"Authorization": "Bearer test-token"},
 			},

--- a/internal/resource/cursor.go
+++ b/internal/resource/cursor.go
@@ -93,6 +93,9 @@ type CursorMCPServer struct {
 
 	// Headers contains HTTP headers for http/sse type servers
 	Headers map[string]string
+
+	// Auth is an optional OAuth configuration for remote servers
+	Auth *MCPAuth
 }
 
 // ResourceType returns the HCL block type for Cursor MCP servers.
@@ -220,6 +223,82 @@ func (r *CursorRules) Validate() error {
 	}
 	if r.Content == "" {
 		return fmt.Errorf("cursor_rules %q: content is required", r.Name)
+	}
+	return nil
+}
+
+// CursorSkill represents a skill for Cursor.
+// Skills are installed to .cursor/skills/{name}/SKILL.md and have a minimal
+// frontmatter (no allowed-tools, model, argument-hint, or context fields).
+type CursorSkill struct {
+	// Name is the block label identifying this skill; must match the parent folder
+	Name string
+
+	// Description explains when and how to use this skill
+	Description string
+
+	// Content is the main body/instructions of the skill
+	Content string
+
+	// Files lists static files to copy alongside the skill
+	Files []FileBlock
+
+	// TemplateFiles lists template files to render and copy
+	TemplateFiles []TemplateFileBlock
+
+	// License is an optional license name or reference to a bundled file
+	License string
+
+	// Compatibility is free-form text describing environment requirements
+	Compatibility string
+
+	// DisableModelInvocation prevents Cursor from auto-loading the skill
+	DisableModelInvocation bool
+
+	// Metadata contains arbitrary additional frontmatter key/value pairs
+	Metadata map[string]string
+}
+
+// ResourceType returns the HCL block type for Cursor skills.
+func (s *CursorSkill) ResourceType() string {
+	return "cursor_skill"
+}
+
+// ResourceName returns the skill's name identifier.
+func (s *CursorSkill) ResourceName() string {
+	return s.Name
+}
+
+// Platform returns the target platform for Cursor skills.
+func (s *CursorSkill) Platform() string {
+	return "cursor"
+}
+
+// GetContent returns the skill's content.
+func (s *CursorSkill) GetContent() string {
+	return s.Content
+}
+
+// GetFiles returns the skill's file blocks.
+func (s *CursorSkill) GetFiles() []FileBlock {
+	return s.Files
+}
+
+// GetTemplateFiles returns the skill's template file blocks.
+func (s *CursorSkill) GetTemplateFiles() []TemplateFileBlock {
+	return s.TemplateFiles
+}
+
+// Validate checks that the skill has all required fields.
+func (s *CursorSkill) Validate() error {
+	if s.Name == "" {
+		return fmt.Errorf("cursor_skill: name is required")
+	}
+	if s.Description == "" {
+		return fmt.Errorf("cursor_skill %q: description is required", s.Name)
+	}
+	if s.Content == "" {
+		return fmt.Errorf("cursor_skill %q: content is required", s.Name)
 	}
 	return nil
 }

--- a/internal/resource/mcp.go
+++ b/internal/resource/mcp.go
@@ -62,6 +62,15 @@ type MCPServerPlatformOverride struct {
 	Headers  map[string]string `hcl:"headers,optional"`
 	Disabled bool              `hcl:"disabled,optional"`
 	Inputs   []MCPInput        `hcl:"input,block"`
+	Auth     *MCPAuth          `hcl:"auth,block"`
+}
+
+// MCPAuth configures OAuth for an MCP server. Currently used by Cursor remote servers.
+// The emitted JSON keys use Cursor's documented casing: CLIENT_ID / CLIENT_SECRET / scopes.
+type MCPAuth struct {
+	ClientID     string   `hcl:"client_id,attr"`
+	ClientSecret string   `hcl:"client_secret,optional"`
+	Scopes       []string `hcl:"scopes,optional"`
 }
 
 // ResourceType returns the HCL block type for unified MCP servers.

--- a/internal/resource/skill.go
+++ b/internal/resource/skill.go
@@ -15,7 +15,18 @@ type Skill struct {
 
 	Claude  *SkillClaudeOverride `hcl:"claude,block"`
 	Copilot *PlatformOverride    `hcl:"copilot,block"`
-	Cursor  *PlatformOverride    `hcl:"cursor,block"`
+	Cursor  *SkillCursorOverride `hcl:"cursor,block"`
+}
+
+// SkillCursorOverride contains Cursor-specific fields for skills.
+// Cursor skills have a minimal frontmatter — no allowed-tools, model, or context fields.
+type SkillCursorOverride struct {
+	Disabled               bool              `hcl:"disabled,optional"`
+	Content                string            `hcl:"content,optional"`
+	License                string            `hcl:"license,optional"`
+	Compatibility          string            `hcl:"compatibility,optional"`
+	DisableModelInvocation bool              `hcl:"disable_model_invocation,optional"`
+	Metadata               map[string]string `hcl:"metadata,optional"`
 }
 
 // SkillClaudeOverride contains Claude-specific fields for skills.

--- a/internal/resource/translator.go
+++ b/internal/resource/translator.go
@@ -114,6 +114,9 @@ func applyCursorOverride(server *CursorMCPServer, override *MCPServerPlatformOve
 	if len(override.Headers) > 0 {
 		server.Headers = override.Headers
 	}
+	if override.Auth != nil {
+		server.Auth = override.Auth
+	}
 }
 
 // TranslateToCopilotMCPServer converts a unified MCPServer to a Copilot-specific MCP server.
@@ -217,6 +220,37 @@ func TranslateToClaudeSkill(s *Skill) *ClaudeSkill {
 		cs.Agent = s.Claude.Agent
 		cs.Metadata = s.Claude.Metadata
 		cs.Hooks = s.Claude.Hooks
+	}
+
+	return cs
+}
+
+// TranslateToCursorSkill converts a universal Skill to a Cursor-specific skill.
+// Returns nil if disabled for Cursor.
+func TranslateToCursorSkill(s *Skill) *CursorSkill {
+	if !s.IsEnabledForPlatform("cursor") {
+		return nil
+	}
+
+	cs := &CursorSkill{
+		Name:          s.Name,
+		Description:   s.Description,
+		Content:       s.Content,
+		Files:         s.Files,
+		TemplateFiles: s.TemplateFiles,
+	}
+
+	if s.Cursor != nil {
+		if s.Cursor.Disabled {
+			return nil
+		}
+		if s.Cursor.Content != "" {
+			cs.Content = s.Cursor.Content
+		}
+		cs.License = s.Cursor.License
+		cs.Compatibility = s.Cursor.Compatibility
+		cs.DisableModelInvocation = s.Cursor.DisableModelInvocation
+		cs.Metadata = s.Cursor.Metadata
 	}
 
 	return cs


### PR DESCRIPTION
- Add Cursor skill support: .cursor/skills/<name>/SKILL.md with the documented minimal frontmatter (name, description, license, compatibility, metadata, disable-model-invocation). New CursorSkill type and SkillCursorOverride.

- Cursor commands now emit plain markdown with no frontmatter, matching Cursor's spec. Previously dex wrote a description: frontmatter that Cursor doesn't parse.

- MCP config now emits type ("stdio" / "http" / "sse") in .cursor/mcp.json, required by modern Cursor schema.

- Add OAuth auth block for Cursor MCP HTTP servers. HCL takes client_id / client_secret / scopes; JSON output uses Cursor's documented casing (CLIENT_ID / CLIENT_SECRET / scopes).

- README platform matrix updated; docs/RESOURCES.md documents Cursor skill support and the new cursor-specific override fields.

Tests updated to assert full expected output rather than substring containment.