### PR TITLE
Fix transitive deps dropping shared-file contributions on re-sync

### DIFF
--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -308,6 +308,14 @@ func (i *Installer) InstallAll() error {
 		}
 	}
 
+	// Collect contributions from any locked packages skipped above —
+	// notably transitive deps that installDependencies() skipped because
+	// they were already locked. Without this, their MCP/settings/agent
+	// contributions would be missing from the regenerated shared files.
+	if err := i.collectAllContributions(); err != nil {
+		return err
+	}
+
 	// Install project-level resources (dedicated files only)
 	if err := i.installProjectResources(); err != nil {
 		return err
@@ -503,7 +511,11 @@ func (i *Installer) installPackage(spec PackageSpec) (*InstalledPackage, error) 
 
 // collectAllContributions reinstalls all locked packages that haven't already
 // been installed in the current session to collect their shared file contributions.
-// This ensures generateSharedFiles() has complete data from all packages.
+// This ensures generateSharedFiles() has complete data from all packages,
+// including transitive dependencies that aren't listed directly in dex.hcl.
+// Without this, transitive deps' MCP servers, settings, and agent content
+// would be dropped from regenerated config files on every re-sync, since
+// installDependencies() skips already-locked deps.
 func (i *Installer) collectAllContributions() error {
 	// Build set of packages already collected
 	collected := make(map[string]bool)
@@ -511,22 +523,37 @@ func (i *Installer) collectAllContributions() error {
 		collected[c.pkgName] = true
 	}
 
-	// Re-install remaining locked packages to collect their contributions
-	for _, pkg := range i.project.Packages {
-		if collected[pkg.Name] {
+	// Index project package configs so we can preserve source/registry/config
+	// when re-installing direct packages.
+	pkgConfigs := make(map[string]config.PackageBlock)
+	for _, p := range i.project.Packages {
+		pkgConfigs[p.Name] = p
+	}
+
+	// Iterate locked packages in a deterministic order so contribution ordering
+	// (which affects agent file content) is stable across runs.
+	names := make([]string, 0, len(i.lock.Packages))
+	for name := range i.lock.Packages {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		if collected[name] {
 			continue
 		}
-		locked := i.lock.Get(pkg.Name)
+		locked := i.lock.Packages[name]
 		if locked == nil {
 			continue
 		}
-		spec := PackageSpec{
-			Name:     pkg.Name,
-			Version:  locked.Version,
-			Source:   pkg.Source,
-			Registry: pkg.Registry,
-			Config:   pkg.Config,
+
+		spec := PackageSpec{Name: name, Version: locked.Version}
+		if p, ok := pkgConfigs[name]; ok {
+			spec.Source = p.Source
+			spec.Registry = p.Registry
+			spec.Config = p.Config
 		}
+
 		if _, err := i.installPackage(spec); err != nil {
 			return err
 		}
@@ -1678,6 +1705,12 @@ func (i *Installer) Sync(dryRun bool) ([]SyncResult, error) {
 
 	// Generate shared files and save if not dry-run
 	if !dryRun {
+		// Collect contributions from transitive deps that were skipped above
+		// (already-locked deps don't go through installPackage during sync).
+		if err := i.collectAllContributions(); err != nil {
+			return nil, err
+		}
+
 		// Install project-level resources
 		if err := i.installProjectResources(); err != nil {
 			return nil, err

--- a/internal/installer/installer_sync_test.go
+++ b/internal/installer/installer_sync_test.go
@@ -1004,6 +1004,107 @@ package "parent-plugin" {
 	assert.True(t, hasChild, "child-plugin (transitive dep) must remain in lock file after sync")
 }
 
+// TestSync_TransitiveDependencyMCPRetainedOnResync reproduces a bug where
+// a transitive dependency's shared-file contributions (MCP servers, settings,
+// agent content) are dropped from the regenerated config files on the second
+// sync.
+//
+// Repro: parent depends on child, and child contributes an mcp_server.
+// First sync installs both — child's installPackage runs (via installDependencies)
+// and adds its contribution. Second sync sees child already locked, so
+// installDependencies skips it; the contribution is never collected, and
+// generateSharedFiles() rewrites .mcp.json without child's server.
+func TestSync_TransitiveDependencyMCPRetainedOnResync(t *testing.T) {
+	projectDir := t.TempDir()
+	registryDir := t.TempDir()
+
+	createLocalRegistryIndex(t, registryDir, map[string][]string{
+		"parent-plugin": {"1.0.0"},
+		"child-plugin":  {"1.0.0"},
+	})
+
+	// child-plugin contributes an MCP server
+	childDir := filepath.Join(registryDir, "child-plugin")
+	require.NoError(t, os.MkdirAll(childDir, 0755))
+	err := os.WriteFile(filepath.Join(childDir, "package.hcl"), []byte(`
+meta {
+  name        = "child-plugin"
+  version     = "1.0.0"
+  description = "Child plugin contributing an MCP server"
+}
+
+mcp_server "child-server" {
+  description = "MCP server from child-plugin"
+  command     = "child-cmd"
+}
+`), 0644)
+	require.NoError(t, err)
+
+	// parent-plugin depends on child-plugin and contributes its own MCP server
+	parentDir := filepath.Join(registryDir, "parent-plugin")
+	require.NoError(t, os.MkdirAll(parentDir, 0755))
+	err = os.WriteFile(filepath.Join(parentDir, "package.hcl"), []byte(`
+meta {
+  name        = "parent-plugin"
+  version     = "1.0.0"
+  description = "Parent plugin"
+}
+
+dependency "child-plugin" {
+  version = ">=1.0.0"
+}
+
+mcp_server "parent-server" {
+  description = "MCP server from parent-plugin"
+  command     = "parent-cmd"
+}
+`), 0644)
+	require.NoError(t, err)
+
+	// Project only references parent-plugin directly
+	createTestProject(t, projectDir, `
+registry "local" {
+  path = "`+registryDir+`"
+}
+
+package "parent-plugin" {
+  registry = "local"
+}
+`)
+
+	mcpPath := filepath.Join(projectDir, ".mcp.json")
+	readServers := func() map[string]any {
+		data, err := os.ReadFile(mcpPath)
+		require.NoError(t, err)
+		var doc map[string]any
+		require.NoError(t, json.Unmarshal(data, &doc))
+		servers, _ := doc["mcpServers"].(map[string]any)
+		return servers
+	}
+
+	// First sync — both servers should be present
+	inst, err := NewInstaller(projectDir, "")
+	require.NoError(t, err)
+	_, err = inst.Sync(false)
+	require.NoError(t, err)
+
+	servers := readServers()
+	assert.Contains(t, servers, "parent-server", "parent-server missing after first sync")
+	assert.Contains(t, servers, "child-server", "child-server missing after first sync")
+
+	// Second sync — bug: child-server is dropped because installDependencies
+	// skips already-locked child-plugin, so its contribution isn't collected
+	inst2, err := NewInstaller(projectDir, "")
+	require.NoError(t, err)
+	_, err = inst2.Sync(false)
+	require.NoError(t, err)
+
+	servers = readServers()
+	assert.Contains(t, servers, "parent-server", "parent-server missing after second sync")
+	assert.Contains(t, servers, "child-server",
+		"child-server (transitive dep contribution) was dropped on re-sync")
+}
+
 // =============================================================================
 // Profile Sync Tests
 // =============================================================================


### PR DESCRIPTION
generateSharedFiles regenerates .mcp.json, settings, and the agent file from scratch using contributions collected from each package's installPackage call. installDependencies skips already-locked deps to avoid re-fetching, so on re-sync a transitive dep's contribution was never collected and its MCP servers / settings / agent content were silently dropped.

collectAllContributions now walks lock.Packages (not just project.Packages) and is invoked from Sync and InstallAll, matching Install and Update.