### PR TITLE
Allow per-registry config in dex.hcl (S3 region)

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -45,6 +45,30 @@ package "my-plugin" {
 	assert.Equal(t, "1.0.0", config.Packages[0].Version)
 }
 
+func TestLoadProject_RegistryConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	hclContent := `
+project {
+  name = "test-project"
+  default_platform = "claude-code"
+}
+
+registry "my-s3" {
+  url = "s3://my-bucket/registry"
+  config = {
+    region = "us-west-2"
+  }
+}
+`
+	err := os.WriteFile(filepath.Join(tmpDir, "dex.hcl"), []byte(hclContent), 0644)
+	require.NoError(t, err)
+
+	config, err := LoadProject(tmpDir)
+	require.NoError(t, err)
+	require.Len(t, config.Registries, 1)
+	assert.Equal(t, "us-west-2", config.Registries[0].Config["region"])
+}
+
 func TestLoadProject_NotFound(t *testing.T) {
 	tmpDir := t.TempDir()
 	// Don't create dex.hcl

--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -152,6 +152,10 @@ type RegistryBlock struct {
 
 	// URL is the remote URL for https:// registries
 	URL string `hcl:"url,optional"`
+
+	// Config holds backend-specific settings (e.g. S3 region) declared in
+	// the file so they win over local SDK defaults / env vars.
+	Config map[string]string `hcl:"config,optional"`
 }
 
 // PackageBlock defines a package dependency.

--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -1103,10 +1103,10 @@ func (i *Installer) resolveRegistry(spec *PackageSpec) (registry.Registry, error
 		for _, reg := range i.project.Registries {
 			if reg.Name == spec.Registry {
 				if reg.Path != "" {
-					return registry.NewRegistry("file:"+reg.Path, registry.ModeRegistry)
+					return registry.NewRegistryWithConfig("file:"+reg.Path, registry.ModeRegistry, reg.Config)
 				}
 				if reg.URL != "" {
-					return registry.NewRegistry(reg.URL, registry.ModeRegistry)
+					return registry.NewRegistryWithConfig(reg.URL, registry.ModeRegistry, reg.Config)
 				}
 			}
 		}
@@ -1161,7 +1161,7 @@ func (i *Installer) searchRegistries(pkgName string) (string, registry.Registry,
 			continue
 		}
 
-		reg, err := registry.NewRegistry(regSource, registry.ModeRegistry)
+		reg, err := registry.NewRegistryWithConfig(regSource, registry.ModeRegistry, regConfig.Config)
 		if err != nil {
 			continue
 		}

--- a/internal/registry/azure.go
+++ b/internal/registry/azure.go
@@ -47,7 +47,11 @@ type AzureRegistry struct {
 // Direct tarball: az://account/container/path/to/package-1.0.0.tar.gz
 //
 // Authentication uses Azure SDK default credential chain.
-func NewAzureRegistry(url string, mode SourceMode) (*AzureRegistry, error) {
+//
+// settings carries backend-specific config from the project's registry block.
+// No keys are recognized yet (endpoint_suffix is planned). Pass nil today.
+func NewAzureRegistry(url string, mode SourceMode, settings map[string]string) (*AzureRegistry, error) {
+	_ = settings // reserved for future use (endpoint_suffix, etc.)
 	// Parse the Azure URL
 	account, container, prefix, err := parseAzureURL(url)
 	if err != nil {

--- a/internal/registry/factory.go
+++ b/internal/registry/factory.go
@@ -19,7 +19,16 @@ import (
 //   - ModeAuto: Auto-detect based on presence of registry.json
 //   - ModeRegistry: Expect registry.json index
 //   - ModePackage: Expect single package with package.hcl
+//
+// For backend-specific overrides (e.g. S3 region), use NewRegistryWithConfig.
 func NewRegistry(url string, mode SourceMode) (Registry, error) {
+	return NewRegistryWithConfig(url, mode, nil)
+}
+
+// NewRegistryWithConfig is like NewRegistry but accepts backend-specific
+// settings declared in the project's registry block (e.g. {"region":
+// "us-west-2"} for S3). Only the S3 and Azure backends consult cfg.
+func NewRegistryWithConfig(url string, mode SourceMode, cfg map[string]string) (Registry, error) {
 	protocol, path, err := ParseSource(url)
 	if err != nil {
 		return nil, err
@@ -39,11 +48,11 @@ func NewRegistry(url string, mode SourceMode) (Registry, error) {
 
 	case "s3":
 		// Reconstruct the full s3:// URL
-		return NewS3Registry("s3://"+path, mode)
+		return NewS3Registry("s3://"+path, mode, cfg)
 
 	case "az":
 		// Reconstruct the full az:// URL
-		return NewAzureRegistry("az://"+path, mode)
+		return NewAzureRegistry("az://"+path, mode, cfg)
 
 	default:
 		return nil, fmt.Errorf("unsupported protocol: %s", protocol)

--- a/internal/registry/s3.go
+++ b/internal/registry/s3.go
@@ -47,7 +47,12 @@ type S3Registry struct {
 // Direct tarball: s3://bucket/path/to/package-1.0.0.tar.gz
 //
 // Authentication uses AWS SDK default credential chain.
-func NewS3Registry(url string, mode SourceMode) (*S3Registry, error) {
+//
+// settings carries backend-specific config from the project's registry block.
+// Recognized keys:
+//   - "region": forces a specific AWS region, taking precedence over
+//     AWS_REGION env / ~/.aws/config. Pass nil when no overrides apply.
+func NewS3Registry(url string, mode SourceMode, settings map[string]string) (*S3Registry, error) {
 	// Parse the S3 URL
 	bucket, prefix, err := parseS3URL(url)
 	if err != nil {
@@ -64,7 +69,12 @@ func NewS3Registry(url string, mode SourceMode) (*S3Registry, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	cfg, err := config.LoadDefaultConfig(ctx)
+	var loadOpts []func(*config.LoadOptions) error
+	if region := settings["region"]; region != "" {
+		loadOpts = append(loadOpts, config.WithRegion(region))
+	}
+
+	cfg, err := config.LoadDefaultConfig(ctx, loadOpts...)
 	if err != nil {
 		return nil, errors.NewRegistryError(url, "connect",
 			fmt.Errorf("failed to load AWS config: %w", err))

--- a/internal/registry/s3_test.go
+++ b/internal/registry/s3_test.go
@@ -103,6 +103,27 @@ func TestS3Registry_Protocol(t *testing.T) {
 	})
 }
 
+func TestNewS3Registry_RegionFromSettings(t *testing.T) {
+	// settings["region"] should be the resolved S3 client region,
+	// taking precedence over AWS_REGION env / ~/.aws/config.
+	t.Setenv("AWS_REGION", "eu-west-1")
+
+	reg, err := NewS3Registry("s3://my-bucket/registry", ModeRegistry, map[string]string{
+		"region": "us-west-2",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "us-west-2", reg.client.Options().Region)
+}
+
+func TestNewS3Registry_NoRegionSettingFallsBackToEnv(t *testing.T) {
+	// Sanity check: without a region setting, the SDK chain picks up AWS_REGION.
+	t.Setenv("AWS_REGION", "ap-southeast-2")
+
+	reg, err := NewS3Registry("s3://my-bucket/registry", ModeRegistry, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "ap-southeast-2", reg.client.Options().Region)
+}
+
 func TestS3Registry_getCacheKey(t *testing.T) {
 	// Test that cache keys are deterministic and unique
 	t.Run("same URL produces same cache key", func(t *testing.T) {

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -222,9 +222,9 @@ func (r *Resolver) getRegistry(source, registryName string) (registry.Registry, 
 		for _, regCfg := range r.project.Registries {
 			if regCfg.Name == registryName {
 				if regCfg.Path != "" {
-					reg, err = registry.NewRegistry("file:"+regCfg.Path, registry.ModeRegistry)
+					reg, err = registry.NewRegistryWithConfig("file:"+regCfg.Path, registry.ModeRegistry, regCfg.Config)
 				} else if regCfg.URL != "" {
-					reg, err = registry.NewRegistry(regCfg.URL, registry.ModeRegistry)
+					reg, err = registry.NewRegistryWithConfig(regCfg.URL, registry.ModeRegistry, regCfg.Config)
 				}
 				break
 			}


### PR DESCRIPTION
Adds a `config = { ... }` map to registry blocks so backend-specific settings declared in dex.hcl take precedence over local SDK defaults (AWS_REGION, ~/.aws/config, etc). S3 honors `config.region` via `config.WithRegion`. Azure accepts the map but ignores keys for now; threading is in place for a follow-up `endpoint_suffix`.